### PR TITLE
feat: add Leaflet.RotatedMarker

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@maxel01/vue-leaflet": "^1.0.0-beta",
+    "@maxel01/vue-leaflet": "^1.0.0-beta.1",
     "leaflet": "^2.0.0-alpha",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
-    "@maxel01/vue-leaflet": "^1.0.0-beta",
+    "@maxel01/vue-leaflet": "^1.0.0-beta.1",
     "@release-it/conventional-changelog": "^8.0.2",
     "@types/leaflet": "^1.9.20",
     "@types/node": "^24.0.14",

--- a/playground/app/pages/leaflet.rotatedmarker/rotated-marker.vue
+++ b/playground/app/pages/leaflet.rotatedmarker/rotated-marker.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { LMap, LTileLayer } from '@maxel01/vue-leaflet'
+import { LRotatedMarker } from '@maxel01/vue-leaflet-plugins'
+</script>
+
+<template>
+    <LMap :zoom="9" :center="[47.41322, -1.219482]">
+        <LTileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            layer-type="base"
+            name="OpenStreetMap"
+        />
+        <LRotatedMarker
+            :latLng="[47.41322, -1.219482]"
+            :rotation-angle="45"
+            draggable
+        />
+    </LMap>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^19.8.1
         version: 19.8.1
       '@maxel01/vue-leaflet':
-        specifier: ^1.0.0-beta
-        version: 1.0.0-beta(leaflet@2.0.0-alpha)(vue@3.5.20(typescript@5.8.3))
+        specifier: ^1.0.0-beta.1
+        version: 1.0.0-beta.1(leaflet@2.0.0-alpha)(vue@3.5.20(typescript@5.8.3))
       '@release-it/conventional-changelog':
         specifier: ^8.0.2
         version: 8.0.2(release-it@17.11.0(typescript@5.8.3))
@@ -1140,6 +1140,12 @@ packages:
 
   '@maxel01/vue-leaflet@1.0.0-beta':
     resolution: {integrity: sha512-qKUzp5cZ6zM1xAPcCIFnDUaRSh0OzH7cyXb7xj30OvTknA5aT0JphAJUo0IoRjI86kK+fgvTxCtuxA8303yhEg==}
+    peerDependencies:
+      leaflet: ^2.0.0-alpha
+      vue: ^3.5.0
+
+  '@maxel01/vue-leaflet@1.0.0-beta.1':
+    resolution: {integrity: sha512-e8x/DL5CBGv3rMaMX9O16AUGmrWcFkwg1wqtarYIdm1LzznoR/+0OcN10G21xl1u68Np1/Q1h+90lQkWDnO3Sw==}
     peerDependencies:
       leaflet: ^2.0.0-alpha
       vue: ^3.5.0
@@ -7507,6 +7513,12 @@ snapshots:
       vue: 3.5.20(typescript@5.8.3)
 
   '@maxel01/vue-leaflet@1.0.0-beta(leaflet@2.0.0-alpha)(vue@3.5.20(typescript@5.8.3))':
+    dependencies:
+      leaflet: 2.0.0-alpha
+      ts-debounce: 4.0.0
+      vue: 3.5.20(typescript@5.8.3)
+
+  '@maxel01/vue-leaflet@1.0.0-beta.1(leaflet@2.0.0-alpha)(vue@3.5.20(typescript@5.8.3))':
     dependencies:
       leaflet: 2.0.0-alpha
       ts-debounce: 4.0.0

--- a/src/leaflet.rotatedmarker/LRotatedMarker.vue
+++ b/src/leaflet.rotatedmarker/LRotatedMarker.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { markRaw, nextTick, onMounted, ref, useAttrs } from 'vue'
+import { AddLayerInjection, assertInject, propsBinder, remapEvents } from '@maxel01/vue-leaflet'
+import { RotatedMarker } from '@/leaflet.rotatedmarker/leaflet.rotatedMarker.ts'
+import {
+    type RotatedMarkerEmits,
+    type RotatedMarkerProps,
+    rotatedMarkerPropsDefaults,
+    setupRotatedMarker
+} from '@/leaflet.rotatedmarker/rotatedMarker.ts'
+
+/**
+ * > Leaflet plugin to enable the rotation of map marker icons
+ * @demo rotated-marker {13-17}
+ */
+defineOptions({})
+const props = withDefaults(defineProps<RotatedMarkerProps>(), rotatedMarkerPropsDefaults)
+const emit = defineEmits<RotatedMarkerEmits>()
+
+const { ready, leafletObject } = useRotatedMarker()
+defineExpose({
+    /**
+     * Indicates whether the component and its underlying Leaflet object are fully initialized.
+     * @type {Ref<boolean>}
+     */
+    ready,
+    /**
+     * The underlying Leaflet instance. Can be used to directly interact with the Leaflet API (e.g. calling methods or accessing internal state).
+     * @type {Ref<Hotline \| undefined>}
+     */
+    leafletObject
+})
+
+function useRotatedMarker() {
+    const leafletObject = ref<RotatedMarker>()
+    const ready = ref(false)
+
+    const addLayer = assertInject(AddLayerInjection)
+
+    const { options, methods } = setupRotatedMarker(props, leafletObject, emit)
+
+    onMounted(async () => {
+        leafletObject.value = markRaw<RotatedMarker>(new RotatedMarker(props.latLng, options))
+
+        const { listeners } = remapEvents(useAttrs())
+        leafletObject.value.on(listeners)
+
+        propsBinder(methods, leafletObject.value, props)
+
+        addLayer({
+            ...props,
+            ...methods,
+            leafletObject: leafletObject.value
+        })
+        ready.value = true
+        nextTick(() => emit('ready', leafletObject.value!))
+    })
+    return { leafletObject, ready }
+}
+</script>
+
+<template>
+    <div></div>
+</template>

--- a/src/leaflet.rotatedmarker/index.ts
+++ b/src/leaflet.rotatedmarker/index.ts
@@ -1,0 +1,1 @@
+export { default as LRotatedMarker } from './LRotatedMarker.vue'

--- a/src/leaflet.rotatedmarker/leaflet.rotatedMarker.ts
+++ b/src/leaflet.rotatedmarker/leaflet.rotatedMarker.ts
@@ -9,10 +9,11 @@ import {
 
 export interface RotatedMarkerOptions extends MarkerOptions {
     rotationAngle?: number
-    rotationOrigin?: PointExpression
+    rotationOrigin?: PointExpression | string
 }
 
 export class RotatedMarker extends Marker {
+    declare options: RotatedMarkerOptions
     constructor(latlng: LatLngExpression, options: RotatedMarkerOptions = {}) {
         super(latlng, options)
         Util.setOptions(this, options)

--- a/src/leaflet.rotatedmarker/leaflet.rotatedMarker.ts
+++ b/src/leaflet.rotatedmarker/leaflet.rotatedMarker.ts
@@ -1,0 +1,60 @@
+import {
+    type LatLngExpression,
+    Marker,
+    type MarkerOptions,
+    Point,
+    type PointExpression,
+    Util
+} from 'leaflet'
+
+export interface RotatedMarkerOptions extends MarkerOptions {
+    rotationAngle?: number
+    rotationOrigin?: PointExpression
+}
+
+export class RotatedMarker extends Marker {
+    constructor(latlng: LatLngExpression, options: RotatedMarkerOptions = {}) {
+        super(latlng, options)
+        Util.setOptions(this, options)
+
+        const iconOptions = options.icon?.options
+        const iconAnchor = iconOptions?.iconAnchor
+
+        const anchorStr = iconAnchor ? `${iconAnchor[0]}px ${iconAnchor[1]}px` : undefined
+
+        this.options.rotationOrigin = options.rotationOrigin || anchorStr || 'center bottom'
+        this.options.rotationAngle = options.rotationAngle || 0
+
+        this.on('drag', (e) => {
+            ;(e.target as RotatedMarker)._applyRotation()
+        })
+    }
+
+    _initIcon() {
+        super['_initIcon']()
+    }
+
+    _setPos(pos: Point) {
+        super['_setPos'](pos)
+        this._applyRotation()
+    }
+
+    private _applyRotation() {
+        if (this.options.rotationAngle) {
+            this._icon.style['transformOrigin'] = this.options.rotationOrigin
+            this._icon.style['transform'] += ` rotate(${this.options.rotationAngle}deg)`
+        }
+    }
+
+    setRotationAngle(angle: number): this {
+        this.options.rotationAngle = angle
+        this.update()
+        return this
+    }
+
+    setRotationOrigin(origin: string): this {
+        this.options.rotationOrigin = origin
+        this.update()
+        return this
+    }
+}

--- a/src/leaflet.rotatedmarker/rotatedMarker.ts
+++ b/src/leaflet.rotatedmarker/rotatedMarker.ts
@@ -1,0 +1,52 @@
+import type { Ref } from 'vue'
+import {
+    type MarkerEmits,
+    type MarkerProps,
+    markerPropsDefaults,
+    propsToLeafletOptions,
+    setupMarker
+} from '@maxel01/vue-leaflet'
+import type {
+    RotatedMarker,
+    RotatedMarkerOptions
+} from '@/leaflet.rotatedmarker/leaflet.rotatedMarker.ts'
+
+export interface RotatedMarkerProps
+    extends MarkerProps {
+    /**
+     * The rotation angle
+     * @reactive
+     */
+    rotationAngle?: number
+    /**
+     * The rotation anchor
+     * @reactive
+     */
+    rotationAnchor?: number
+}
+
+export const rotatedMarkerPropsDefaults = {
+    ...markerPropsDefaults
+}
+
+export interface RotatedMarkerEmits extends MarkerEmits {}
+
+export const setupRotatedMarker = (
+    props: RotatedMarkerProps,
+    leafletRef: Ref<RotatedMarker | undefined>,
+    emit: RotatedMarkerEmits
+) => {
+    const { options: rotatedMarkerOptions, methods: rotatedMarkerMethods } = setupMarker(
+        props,
+        leafletRef,
+        emit
+    )
+
+    const options = propsToLeafletOptions<RotatedMarkerOptions>(props, rotatedMarkerOptions)
+
+    const methods = {
+        ...rotatedMarkerMethods
+    }
+
+    return { options, methods }
+}

--- a/src/leaflet.rotatedmarker/rotatedMarker.ts
+++ b/src/leaflet.rotatedmarker/rotatedMarker.ts
@@ -10,6 +10,7 @@ import type {
     RotatedMarker,
     RotatedMarkerOptions
 } from '@/leaflet.rotatedmarker/leaflet.rotatedMarker'
+import type { PointExpression } from 'leaflet'
 
 export interface RotatedMarkerProps extends MarkerProps {
     /**
@@ -21,7 +22,7 @@ export interface RotatedMarkerProps extends MarkerProps {
      * The rotation origin
      * @reactive
      */
-    rotationOrigin?: [number, number]
+    rotationOrigin?: PointExpression | string
 }
 
 export const rotatedMarkerPropsDefaults = {

--- a/src/leaflet.rotatedmarker/rotatedMarker.ts
+++ b/src/leaflet.rotatedmarker/rotatedMarker.ts
@@ -9,20 +9,19 @@ import {
 import type {
     RotatedMarker,
     RotatedMarkerOptions
-} from '@/leaflet.rotatedmarker/leaflet.rotatedMarker.ts'
+} from '@/leaflet.rotatedmarker/leaflet.rotatedMarker'
 
-export interface RotatedMarkerProps
-    extends MarkerProps {
+export interface RotatedMarkerProps extends MarkerProps {
     /**
      * The rotation angle
      * @reactive
      */
     rotationAngle?: number
     /**
-     * The rotation anchor
+     * The rotation origin
      * @reactive
      */
-    rotationAnchor?: number
+    rotationOrigin?: [number, number]
 }
 
 export const rotatedMarkerPropsDefaults = {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,1 +1,2 @@
 export * from './leaflet.hotline'
+export * from './leaflet.rotatedmarker'

--- a/tests/leaflet.rotatedmarker/LRotatedMarker.test.ts
+++ b/tests/leaflet.rotatedmarker/LRotatedMarker.test.ts
@@ -1,0 +1,69 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import {
+    mergeReactiveProps,
+    mockAddLayer,
+    mockRemoveLayer,
+    testAddLayer,
+    testEmitsReady,
+    testPropsBindingToLeaflet,
+    testRemoveLayerOnUnmount
+} from '@maxel01/vue-leaflet/tests'
+import { AddLayerInjection, RemoveLayerInjection } from '@maxel01/vue-leaflet'
+import type { RotatedMarker } from '@/leaflet.rotatedmarker/leaflet.rotatedMarker'
+import { LRotatedMarker } from '@/leaflet.rotatedmarker'
+import { LatLng } from 'leaflet'
+
+const rotatedMarkerProps = mergeReactiveProps(
+    {} /* TEST markerProps */,
+    {
+        rotationAngle: 60,
+        rotationOrigin: [4, 4],
+        expecting: {
+            rotationOrigin: (leafletObject: RotatedMarker) => {
+                expect(leafletObject.options.rotationOrigin).toStrictEqual(
+                    rotatedMarkerProps.rotationOrigin
+                )
+            }
+        }
+    }
+)
+
+export const createWrapper = async (props = {}, slots = {}) => {
+    const wrapper = mount(LRotatedMarker, {
+        propsData: {
+            latLng: [44.48865, 11.3317],
+            ...props
+        },
+        slots: slots,
+        global: {
+            provide: {
+                [AddLayerInjection as symbol]: mockAddLayer,
+                [RemoveLayerInjection as symbol]: mockRemoveLayer
+            }
+        }
+    })
+
+    await flushPromises()
+    return wrapper
+}
+
+describe('LRotatedMarker.vue', () => {
+    testEmitsReady(createWrapper)
+    // TEST testComponentPropBindings(createMarkerWrapper, 'LRotatedMarker')
+    testPropsBindingToLeaflet(createWrapper, rotatedMarkerProps)
+    testRemoveLayerOnUnmount(createWrapper)
+
+    testCorrectInitialisation(createWrapper)
+    testAddLayer(createWrapper)
+})
+
+const testCorrectInitialisation = (getWrapper: () => Promise<VueWrapper<any>>) => {
+    it('creates a Leaflet rotated marker with correct options', async () => {
+        const wrapper = await getWrapper()
+        const obj = wrapper.vm.leafletObject as RotatedMarker
+
+        expect(obj).toBeDefined()
+        expect(obj.getLatLng()).toStrictEqual(new LatLng(44.48865, 11.3317))
+    })
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,5 +15,5 @@
     // this duplication is for VSCode; also see tsconfig.json
     "types": ["node", "vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts"]
 }


### PR DESCRIPTION
This PR adds the Leaflet.RotatedMarker plugin.
It includes:
- src
- playground
- tests