### PR TITLE
fix(playground-vue): add missing imports

### DIFF
--- a/playground/app/pages/leaflet.rotatedmarker/index.vue
+++ b/playground/app/pages/leaflet.rotatedmarker/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import { LMap, LTileLayer } from '@maxel01/vue-leaflet'
 import { LRotatedMarker } from '@maxel01/vue-leaflet-plugins'
 


### PR DESCRIPTION
works in Nuxt with auto-imports, but is needed in vue and the docs