### PR TITLE
docs: fix failed vitepress build due to npm package of this lib

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,10 @@ jobs:
         uses: actions/configure-pages@v4
       - name: Install dependencies
         run: pnpm install
+      - name: Build vue-leaflet-plugins
+        run: pnpm run build
+      - name: Install dependencies
+        run: pnpm install
       - name: Build with VitePress
         run: pnpm run docs:build
       - name: Upload artifact

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
     base: '/vue-leaflet-plugins/',
     vite: {
         resolve: {
-            alias
+            alias: {
+                ...alias,
+                '@maxel01/vue-leaflet-plugins': '@dist/vue-leaflet-plugins',
+            }
         }
     },
     themeConfig: {

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,5 +1,7 @@
 import DefaultTheme from 'vitepress/theme'
 import './custom.css'
+import 'leaflet/dist/leaflet.css'
+import '../../../dist/vue-leaflet-plugins.css'
 
 /** @type {import('vitepress').Theme} */
 export default {

--- a/docs/plugins/introduction.md
+++ b/docs/plugins/introduction.md
@@ -14,4 +14,5 @@ The module provides the following plugins:
 
 - [`Leaflet.Donut`](/plugins/leaflet.donut/)
 - [`Leaflet.Hotline`](/plugins/leaflet.hotline/)
+- [`Leaflet.MarkerCluster`](/plugins/leaflet.markercluster/)
 - [`Leaflet.RotatedMarker`](/plugins/leaflet.rotatedmarker/)

--- a/docs/plugins/leaflet.donut/index.md
+++ b/docs/plugins/leaflet.donut/index.md
@@ -12,10 +12,6 @@ A Leaflet plugin for drawing circles with an inner radius (donut).
 
 ## 🧪 Playground
 
-<script>
-import "leaflet/dist/leaflet.css";
-</script>
-
 <div class="demo">
     <demo-leaflet.donut-index />
 </div>

--- a/docs/plugins/leaflet.hotline/index.md
+++ b/docs/plugins/leaflet.hotline/index.md
@@ -12,10 +12,6 @@ A Leaflet plugin for drawing colored gradients along polylines. This is useful f
 
 ## 🧪 Playground
 
-<script>
-import "leaflet/dist/leaflet.css";
-</script>
-
 <div class="demo">
     <demo-leaflet.hotline-index />
 </div>

--- a/docs/plugins/leaflet.markercluster/index.md
+++ b/docs/plugins/leaflet.markercluster/index.md
@@ -6,6 +6,14 @@ title: Leaflet.RotatedMarker
 
 Provides Beautiful Animated Marker Clustering functionality for Leaflet, a JS library for interactive maps.
 
+::: tip Requirements
+Make sure to import the css file:
+
+```js
+import "@maxel01/vue-leaflet-plugins/dist/vue-leaflet-plugins.css"
+```
+:::
+
 ## 🧩 Available Components
 
 - [`LMarkerClusterGroup`](/plugins/leaflet.markercluster/l-marker-cluster-group)

--- a/docs/plugins/leaflet.markercluster/index.md
+++ b/docs/plugins/leaflet.markercluster/index.md
@@ -12,10 +12,6 @@ Provides Beautiful Animated Marker Clustering functionality for Leaflet, a JS li
 
 ## 🧪 Playground
 
-<script>
-import "leaflet/dist/leaflet.css";
-</script>
-
 <div class="demo">
     <demo-leaflet.markercluster-index />
 </div>

--- a/docs/plugins/leaflet.rotatedmarker/index.md
+++ b/docs/plugins/leaflet.rotatedmarker/index.md
@@ -12,10 +12,6 @@ Enables rotation of marker icons in Leaflet.
 
 ## 🧪 Playground
 
-<script>
-import "leaflet/dist/leaflet.css";
-</script>
-
 <div class="demo">
     <demo-leaflet.rotatedmarker-index />
 </div>

--- a/docs/scripts/generate-docs.js
+++ b/docs/scripts/generate-docs.js
@@ -75,9 +75,6 @@ function writeDemo(doc, markdown, pluginName) {
         const [demoName, highlight] = demo.description.split(' ')
         markdown +=
             '## 🧪 Demo\n\n' +
-            '<script>\n' +
-            'import "leaflet/dist/leaflet.css";\n' +
-            '</script>\n\n' +
             '<div class="demo">\n' +
             `    <demo-${pluginName}-${demoName} />\n` +
             '</div>\n\n' +

--- a/playground/app/pages/leaflet.markercluster/index.vue
+++ b/playground/app/pages/leaflet.markercluster/index.vue
@@ -4,8 +4,6 @@ import { LMarkerClusterGroup } from '@maxel01/vue-leaflet-plugins'
 import { LatLng, Map } from 'leaflet'
 import { ref } from 'vue'
 
-// TODO does not work in vitepress
-
 const markers = ref<LatLng[]>([])
 
 function getRandomLatLng(map: Map) {

--- a/playground/app/pages/leaflet.markercluster/marker-cluster-group.vue
+++ b/playground/app/pages/leaflet.markercluster/marker-cluster-group.vue
@@ -4,8 +4,6 @@ import { LMarkerClusterGroup } from '@maxel01/vue-leaflet-plugins'
 import { LatLng, Map } from 'leaflet'
 import { ref } from 'vue'
 
-// TODO does not work in vitepress
-
 const markers = ref<LatLng[]>([])
 
 function getRandomLatLng(map: Map) {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -13,7 +13,7 @@ export default defineNuxtConfig({
     ssr: true,
     compatibilityDate: '2025-07-15',
     devtools: { enabled: true },
-    css: ['leaflet/dist/leaflet.css'],
+    css: ['leaflet/dist/leaflet.css', "@maxel01/vue-leaflet-plugins/dist/vue-leaflet-plugins.css"],
     app: {
         head: {
             link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]

--- a/src/leaflet.markercluster/LMarkerClusterGroup.vue
+++ b/src/leaflet.markercluster/LMarkerClusterGroup.vue
@@ -14,7 +14,7 @@ import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 
 /**
  * > Provides Beautiful Animated Marker Clustering functionality for Leaflet, a JS library for interactive maps.
- * @demo marker-cluster-group {9-23,33-39}
+ * @demo marker-cluster-group {7-21,31-37}
  */
 defineOptions({})
 const props = withDefaults(defineProps<MarkerClusterGroupProps>(), markerClusterGroupPropsDefaults)

--- a/src/utils/libs/leaflet-v1-polyfill.js
+++ b/src/utils/libs/leaflet-v1-polyfill.js
@@ -277,7 +277,7 @@ function applyUtilPolyfill() {
 		}
 		return dest;
 	};
-	
+
 	L.extend = L.Util.extend;
 	L.bind = L.Util.bind;
 	L.stamp = L.Util.stamp;
@@ -299,7 +299,7 @@ function applyMouseEventPolyfill() {
 		mouseEventToLatLng(e) {
 			return this.pointerEventToLatLng(e);
 		},
-	
+
 		// Fallback bubblingMouseEvents
 		_findEventTargets(e, type) {
 			const targets = _super_findEventTargets.call(this, e, type);
@@ -310,7 +310,7 @@ function applyMouseEventPolyfill() {
 			}
 			return targets;
 		},
-	
+
 		// Add support for mouse events
 		_initEvents(remove) {
 			_super_initEvents.call(this, remove);
@@ -318,7 +318,7 @@ function applyMouseEventPolyfill() {
 			onOff(this._container, 'mousedown mouseup mouseover mouseout mousemove', this._handleDOMEvent, this);
 		}
 	});
-	
+
 	const _super_disableClickPropagation = L.DomEvent.disableClickPropagation;
 	L.DomEvent.disableClickPropagation = function disableClickPropagation(el) {
 		L.DomEvent.on(el, 'mousedown touchstart', L.DomEvent.stopPropagation);
@@ -532,13 +532,15 @@ function applyMiscPolyfill() {
 	document.head.appendChild(ccsStyle);
 }
 
-globalThis.applyAllPolyfills = applyAllPolyfills;
-globalThis.applyMinimumPolyfills = applyMinimumPolyfills;
-globalThis.applyBrowserPolyfill = applyBrowserPolyfill;
-globalThis.applyDomUtilPolyfill = applyDomUtilPolyfill;
-globalThis.applyUtilPolyfill = applyUtilPolyfill;
-globalThis.applyMouseEventPolyfill = applyMouseEventPolyfill;
-globalThis.applyDomEventPolyfill = applyDomEventPolyfill;
-globalThis.applyDeprecatedMethodsPolyfill = applyDeprecatedMethodsPolyfill;
-globalThis.applyFactoryMethodsPolyfill = applyFactoryMethodsPolyfill;
-globalThis.applyMiscPolyfill = applyMiscPolyfill;
+export {
+    applyAllPolyfills,
+    applyMinimumPolyfills,
+    applyBrowserPolyfill,
+    applyDomUtilPolyfill,
+    applyUtilPolyfill,
+    applyMouseEventPolyfill,
+    applyDomEventPolyfill,
+    applyDeprecatedMethodsPolyfill,
+    applyFactoryMethodsPolyfill,
+    applyMiscPolyfill
+}

--- a/src/utils/polyfill.ts
+++ b/src/utils/polyfill.ts
@@ -1,5 +1,5 @@
 import L from 'leaflet'
-import './libs/leaflet-v1-polyfill'
+import { applyAllPolyfills } from './libs/leaflet-v1-polyfill'
 
 export function preparePolyfill() {
     window.L = L


### PR DESCRIPTION
Vitepress builds failed because the new components were not already in the published npm package. Vitepress uses the local build for that.
MarkerCluster works in the build too.
This has been resolved by explicitly exporting the functions from ``leaflet-v1-polyfill``.
