### PR TITLE
fix(deps): pin ``leaflet`` version to ``2.0.0-alpha``

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@maxel01/vue-leaflet": "^1.0.0-beta.1",
-    "leaflet": "^2.0.0-alpha",
+    "leaflet": "2.0.0-alpha",
     "vue": "^3.5.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       leaflet:
-        specifier: ^2.0.0-alpha
+        specifier: 2.0.0-alpha
         version: 2.0.0-alpha
       leaflet.markercluster:
         specifier: ^1.5.3


### PR DESCRIPTION
The ``leaflet`` version is pinned to ``2.0.0-alpha`` as ``2.0.0-alpha.1`` is not compatible with hotline.
That version is not compatible with ``Hotline`` which is caused by this PR: Leaflet/Leaflet#9815
This has been reverted in Leaflet/Leaflet#9849, however no version with this PR has been released yet.