### PR TITLE
test: add `markerProps` to tests in RotatedMarker

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@maxel01/vue-leaflet": "^1.0.0-beta.1",
+    "@maxel01/vue-leaflet": "^1.0.0-beta.2",
     "leaflet": "2.0.0-alpha",
     "vue": "^3.5.0"
   },
   "devDependencies": {
-    "@maxel01/vue-leaflet": "^1.0.0-beta.1",
+    "@maxel01/vue-leaflet": "^1.0.0-beta.2",
     "@release-it/conventional-changelog": "^10.0.1",
     "@types/leaflet": "^1.9.20",
     "@types/leaflet.markercluster": "^1.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 0.4.0
     devDependencies:
       '@maxel01/vue-leaflet':
-        specifier: ^1.0.0-beta.1
-        version: 1.0.0-beta.1(leaflet@2.0.0-alpha)(vue@3.5.22(typescript@5.8.3))
+        specifier: ^1.0.0-beta.2
+        version: 1.0.0-beta.2(leaflet@2.0.0-alpha)(vue@3.5.22(typescript@5.8.3))
       '@release-it/conventional-changelog':
         specifier: ^10.0.1
         version: 10.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.2.0)(release-it@19.0.5(@types/node@24.3.0)(magicast@0.3.5))
@@ -1047,6 +1047,12 @@ packages:
 
   '@maxel01/vue-leaflet@1.0.0-beta.1':
     resolution: {integrity: sha512-e8x/DL5CBGv3rMaMX9O16AUGmrWcFkwg1wqtarYIdm1LzznoR/+0OcN10G21xl1u68Np1/Q1h+90lQkWDnO3Sw==}
+    peerDependencies:
+      leaflet: ^2.0.0-alpha
+      vue: ^3.5.0
+
+  '@maxel01/vue-leaflet@1.0.0-beta.2':
+    resolution: {integrity: sha512-IA9vO1wrh4kN1JUL2DYKKBP3kbkbhaAUhBsRncG+sr5g7Aaeqv39TVkza3oM4iBohROEEoqnb0uVgj89IAMnRQ==}
     peerDependencies:
       leaflet: ^2.0.0-alpha
       vue: ^3.5.0
@@ -6731,6 +6737,12 @@ snapshots:
       vue: 3.5.22(typescript@5.8.3)
 
   '@maxel01/vue-leaflet@1.0.0-beta.1(leaflet@2.0.0-alpha)(vue@3.5.22(typescript@5.8.3))':
+    dependencies:
+      leaflet: 2.0.0-alpha
+      ts-debounce: 4.0.0
+      vue: 3.5.22(typescript@5.8.3)
+
+  '@maxel01/vue-leaflet@1.0.0-beta.2(leaflet@2.0.0-alpha)(vue@3.5.22(typescript@5.8.3))':
     dependencies:
       leaflet: 2.0.0-alpha
       ts-debounce: 4.0.0

--- a/tests/leaflet.rotatedmarker/LRotatedMarker.test.ts
+++ b/tests/leaflet.rotatedmarker/LRotatedMarker.test.ts
@@ -1,6 +1,7 @@
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import {
+    markerProps,
     mergeReactiveProps,
     mockAddLayer,
     mockRemoveLayer,
@@ -14,20 +15,17 @@ import type { RotatedMarker } from '@/libs/leaflet.rotatedmarker/leaflet.rotated
 import { LRotatedMarker } from '@/leaflet.rotatedmarker'
 import { LatLng } from 'leaflet'
 
-const rotatedMarkerProps = mergeReactiveProps(
-    {} /* TEST markerProps */,
-    {
-        rotationAngle: 60,
-        rotationOrigin: [4, 4],
-        expecting: {
-            rotationOrigin: (leafletObject: RotatedMarker) => {
-                expect(leafletObject.options.rotationOrigin).toStrictEqual(
-                    rotatedMarkerProps.rotationOrigin
-                )
-            }
+const rotatedMarkerProps = mergeReactiveProps(markerProps, {
+    rotationAngle: 60,
+    rotationOrigin: [4, 4],
+    expecting: {
+        rotationOrigin: (leafletObject: RotatedMarker) => {
+            expect(leafletObject.options.rotationOrigin).toStrictEqual(
+                rotatedMarkerProps.rotationOrigin
+            )
         }
     }
-)
+})
 
 export const createWrapper = async (props = {}, slots = {}) => {
     const wrapper = mount(LRotatedMarker, {


### PR DESCRIPTION
Vue-Leaflet's new [beta version](https://github.com/Maxel01/vue-leaflet/releases/tag/v1.0.0-beta.2) now exports all test props. Therefore, the tests in ``LRotatedMarker`` can now use `markerProps`.